### PR TITLE
Update printer-anycubic-kossel-plus-2017.cfg

### DIFF
--- a/config/printer-anycubic-kossel-plus-2017.cfg
+++ b/config/printer-anycubic-kossel-plus-2017.cfg
@@ -56,6 +56,7 @@ pid_Kd: 132.130
 min_extrude_temp: 150
 min_temp: 0
 max_temp: 275
+max_extrude_cross_section: 4
 
 [heater_bed]
 heater_pin: PH5


### PR DESCRIPTION
without
max_extrude_cross_section: 4
at extruder config the kossel linear dosn´t work an give the print in some seconds.
